### PR TITLE
Fix for exact matches

### DIFF
--- a/base.sh
+++ b/base.sh
@@ -18,6 +18,7 @@ function getDnsExitDomain () {
   unset dnsExitMatchingDomain
   if [ ! -z ${dnsExitDomainMap[$certbotDomain]:-} ]; then
     dnsExitMatchingDomain="$certbotDomain"
+    dnsExitMatchingDomainFound=true
   fi
 
   # if we were unable to match the domain using exact match then try to match with its variants (for subdomains)


### PR DESCRIPTION
When certbot domain matches exactly with one of the dnsexit domains, set the flag indicating a match.